### PR TITLE
Updated nuget package icon url

### DIFF
--- a/Cake.PathTildeHelper/Cake.PathTildeHelper.csproj
+++ b/Cake.PathTildeHelper/Cake.PathTildeHelper.csproj
@@ -7,7 +7,7 @@
     <Copyright>© 2018 Adam Patridge</Copyright>
     <PackageLicenseUrl>https://github.com/patridge/Cake.PathTildeHelper/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/patridge/Cake.PathTildeHelper</PackageProjectUrl>
-    <PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png</PackageIconUrl>
+    <PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/addin/cake-contrib-addin-medium.png</PackageIconUrl>
     <PackageTags>Cake Script Build</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION
Updated Nuget Package Icon to the add-in url given at https://github.com/cake-contrib/graphics
Fixes Issue #4 